### PR TITLE
Fix tests module

### DIFF
--- a/src/decrypter.rs
+++ b/src/decrypter.rs
@@ -125,7 +125,6 @@ impl std::fmt::Display for DecryptError {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use aes_ctr::stream_cipher::NewStreamCipher;
 
 	#[test]
 	fn increase_iv() {


### PR DESCRIPTION
Compiling the tests module fails because of a missing import:

error[E0433]: failed to resolve: use of undeclared type or module `aes_ctr`
   --> src/decrypter.rs:128:6
    |
128 |     use aes_ctr::stream_cipher::NewStreamCipher;
    |         ^^^^^^^ use of undeclared type or module `aes_ctr`

It turned out, however, that NewStreamCipher is never used. Therefore,
it is sufficient to remove the problematic import line.

warning: unused import: `aes_ctr::stream_cipher::NewStreamCipher`
   --> src/decrypter.rs:128:6
    |
128 |     use aes_ctr::stream_cipher::NewStreamCipher;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |