### PR TITLE
Support new backup file format

### DIFF
--- a/proto/Backups.proto
+++ b/proto/Backups.proto
@@ -8,8 +8,7 @@ syntax = "proto2";
 
 package signal;
 
-option java_package         = "org.thoughtcrime.securesms.backup";
-option java_outer_classname = "BackupProtos";
+option java_package = "org.thoughtcrime.securesms.backup.proto";
 
 message SqlStatement {
     message SqlParameter {
@@ -55,8 +54,9 @@ message DatabaseVersion {
 }
 
 message Header {
-    optional bytes iv   = 1;
-    optional bytes salt = 2;
+    optional bytes  iv      = 1;
+    optional bytes  salt    = 2;
+    optional uint32 version = 3;
 }
 
 message KeyValue {

--- a/src/Backups.rs
+++ b/src/Backups.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]
@@ -1821,6 +1820,7 @@ pub struct Header {
     // message fields
     iv: ::protobuf::SingularField<::std::vec::Vec<u8>>,
     salt: ::protobuf::SingularField<::std::vec::Vec<u8>>,
+    version: ::std::option::Option<u32>,
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
     pub cached_size: ::protobuf::CachedSize,
@@ -1908,6 +1908,25 @@ impl Header {
     pub fn take_salt(&mut self) -> ::std::vec::Vec<u8> {
         self.salt.take().unwrap_or_else(|| ::std::vec::Vec::new())
     }
+
+    // optional uint32 version = 3;
+
+
+    pub fn get_version(&self) -> u32 {
+        self.version.unwrap_or(0)
+    }
+    pub fn clear_version(&mut self) {
+        self.version = ::std::option::Option::None;
+    }
+
+    pub fn has_version(&self) -> bool {
+        self.version.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_version(&mut self, v: u32) {
+        self.version = ::std::option::Option::Some(v);
+    }
 }
 
 impl ::protobuf::Message for Header {
@@ -1924,6 +1943,13 @@ impl ::protobuf::Message for Header {
                 },
                 2 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.salt)?;
+                },
+                3 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_uint32()?;
+                    self.version = ::std::option::Option::Some(tmp);
                 },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
@@ -1943,6 +1969,9 @@ impl ::protobuf::Message for Header {
         if let Some(ref v) = self.salt.as_ref() {
             my_size += ::protobuf::rt::bytes_size(2, &v);
         }
+        if let Some(v) = self.version {
+            my_size += ::protobuf::rt::value_size(3, v, ::protobuf::wire_format::WireTypeVarint);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
@@ -1954,6 +1983,9 @@ impl ::protobuf::Message for Header {
         }
         if let Some(ref v) = self.salt.as_ref() {
             os.write_bytes(2, &v)?;
+        }
+        if let Some(v) = self.version {
+            os.write_uint32(3, v)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -2003,6 +2035,11 @@ impl ::protobuf::Message for Header {
                 |m: &Header| { &m.salt },
                 |m: &mut Header| { &mut m.salt },
             ));
+            fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                "version",
+                |m: &Header| { &m.version },
+                |m: &mut Header| { &mut m.version },
+            ));
             ::protobuf::reflect::MessageDescriptor::new_pb_name::<Header>(
                 "Header",
                 fields,
@@ -2021,6 +2058,7 @@ impl ::protobuf::Clear for Header {
     fn clear(&mut self) {
         self.iv.clear();
         self.salt.clear();
+        self.version = ::std::option::Option::None;
         self.unknown_fields.clear();
     }
 }
@@ -3099,24 +3137,25 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x06Avatar\x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x20\n\x0bre\
     cipientId\x18\x03\x20\x01(\tR\x0brecipientId\x12\x16\n\x06length\x18\x02\
     \x20\x01(\rR\x06length\"+\n\x0fDatabaseVersion\x12\x18\n\x07version\x18\
-    \x01\x20\x01(\rR\x07version\",\n\x06Header\x12\x0e\n\x02iv\x18\x01\x20\
-    \x01(\x0cR\x02iv\x12\x12\n\x04salt\x18\x02\x20\x01(\x0cR\x04salt\"\xe2\
-    \x01\n\x08KeyValue\x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x1c\n\
-    \tblobValue\x18\x02\x20\x01(\x0cR\tblobValue\x12\"\n\x0cbooleanValue\x18\
-    \x03\x20\x01(\x08R\x0cbooleanValue\x12\x1e\n\nfloatValue\x18\x04\x20\x01\
-    (\x02R\nfloatValue\x12\"\n\x0cintegerValue\x18\x05\x20\x01(\x05R\x0cinte\
-    gerValue\x12\x1c\n\tlongValue\x18\x06\x20\x01(\x03R\tlongValue\x12\x20\n\
-    \x0bstringValue\x18\x07\x20\x01(\tR\x0bstringValue\"\x9d\x03\n\x0bBackup\
-    Frame\x12&\n\x06header\x18\x01\x20\x01(\x0b2\x0e.signal.HeaderR\x06heade\
-    r\x122\n\tstatement\x18\x02\x20\x01(\x0b2\x14.signal.SqlStatementR\tstat\
-    ement\x128\n\npreference\x18\x03\x20\x01(\x0b2\x18.signal.SharedPreferen\
-    ceR\npreference\x122\n\nattachment\x18\x04\x20\x01(\x0b2\x12.signal.Atta\
-    chmentR\nattachment\x121\n\x07version\x18\x05\x20\x01(\x0b2\x17.signal.D\
-    atabaseVersionR\x07version\x12\x10\n\x03end\x18\x06\x20\x01(\x08R\x03end\
-    \x12&\n\x06avatar\x18\x07\x20\x01(\x0b2\x0e.signal.AvatarR\x06avatar\x12\
-    )\n\x07sticker\x18\x08\x20\x01(\x0b2\x0f.signal.StickerR\x07sticker\x12,\
-    \n\x08keyValue\x18\t\x20\x01(\x0b2\x10.signal.KeyValueR\x08keyValueB1\n!\
-    org.thoughtcrime.securesms.backupB\x0cBackupProtos\
+    \x01\x20\x01(\rR\x07version\"F\n\x06Header\x12\x0e\n\x02iv\x18\x01\x20\
+    \x01(\x0cR\x02iv\x12\x12\n\x04salt\x18\x02\x20\x01(\x0cR\x04salt\x12\x18\
+    \n\x07version\x18\x03\x20\x01(\rR\x07version\"\xe2\x01\n\x08KeyValue\x12\
+    \x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x1c\n\tblobValue\x18\x02\
+    \x20\x01(\x0cR\tblobValue\x12\"\n\x0cbooleanValue\x18\x03\x20\x01(\x08R\
+    \x0cbooleanValue\x12\x1e\n\nfloatValue\x18\x04\x20\x01(\x02R\nfloatValue\
+    \x12\"\n\x0cintegerValue\x18\x05\x20\x01(\x05R\x0cintegerValue\x12\x1c\n\
+    \tlongValue\x18\x06\x20\x01(\x03R\tlongValue\x12\x20\n\x0bstringValue\
+    \x18\x07\x20\x01(\tR\x0bstringValue\"\x9d\x03\n\x0bBackupFrame\x12&\n\
+    \x06header\x18\x01\x20\x01(\x0b2\x0e.signal.HeaderR\x06header\x122\n\tst\
+    atement\x18\x02\x20\x01(\x0b2\x14.signal.SqlStatementR\tstatement\x128\n\
+    \npreference\x18\x03\x20\x01(\x0b2\x18.signal.SharedPreferenceR\nprefere\
+    nce\x122\n\nattachment\x18\x04\x20\x01(\x0b2\x12.signal.AttachmentR\natt\
+    achment\x121\n\x07version\x18\x05\x20\x01(\x0b2\x17.signal.DatabaseVersi\
+    onR\x07version\x12\x10\n\x03end\x18\x06\x20\x01(\x08R\x03end\x12&\n\x06a\
+    vatar\x18\x07\x20\x01(\x0b2\x0e.signal.AvatarR\x06avatar\x12)\n\x07stick\
+    er\x18\x08\x20\x01(\x0b2\x0f.signal.StickerR\x07sticker\x12,\n\x08keyVal\
+    ue\x18\t\x20\x01(\x0b2\x10.signal.KeyValueR\x08keyValueB1\n!org.thoughtc\
+    rime.securesms.backupB\x0cBackupProtos\
 ";
 
 static file_descriptor_proto_lazy: ::protobuf::rt::LazyV2<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::rt::LazyV2::INIT;

--- a/src/decrypter.rs
+++ b/src/decrypter.rs
@@ -45,11 +45,13 @@ impl Decrypter {
 		}
 	}
 
-	pub fn decrypt(&mut self, data_encrypted: &[u8]) -> Vec<u8> {
+	pub fn decrypt(&mut self, data_encrypted: &[u8], update_hmac: bool) -> Vec<u8> {
 		// check hmac?
-		if let Some(ref mut hmac) = self.mac {
-			// calculate hmac of frame data
-			hmac.update(&data_encrypted);
+		if update_hmac {
+			if let Some(ref mut hmac) = self.mac {
+				// calculate hmac of frame data
+				hmac.update(&data_encrypted);
+			}
 		}
 
 		// decrypt

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -6,6 +6,7 @@ pub enum Frame {
 	Header {
 		salt: Vec<u8>,
 		iv: Vec<u8>,
+		version: u32,
 	},
 	Statement {
 		statement: String,
@@ -35,15 +36,14 @@ pub enum Frame {
 		data: Option<Vec<u8>>,
 	},
 	KeyValue {
-		key_value: crate::Backups::KeyValue
-		    // optional string key          = 1;
-    // optional bytes  blobValue    = 2;
-    // optional bool   booleanValue = 3;
-    // optional float  floatValue   = 4;
-    // optional int32  integerValue = 5;
-    // optional int64  longValue    = 6;
-    // optional string stringValue  = 7;
-	}
+		key_value: crate::Backups::KeyValue, // optional string key          = 1;
+		                                     // optional bytes  blobValue    = 2;
+		                                     // optional bool   booleanValue = 3;
+		                                     // optional float  floatValue   = 4;
+		                                     // optional int32  integerValue = 5;
+		                                     // optional int64  longValue    = 6;
+		                                     // optional string stringValue  = 7;
+	},
 }
 
 impl Frame {
@@ -57,6 +57,7 @@ impl Frame {
 			ret = Some(Self::Header {
 				salt: header.take_salt(),
 				iv: header.take_iv(),
+				version: header.get_version(),
 			});
 		};
 
@@ -140,9 +141,7 @@ impl Frame {
 		if frame.has_keyValue() {
 			fields_count += 1;
 			let key_value = frame.take_keyValue();
-			ret = Some(Self::KeyValue {
-				key_value
-			});
+			ret = Some(Self::KeyValue { key_value });
 		};
 
 		if fields_count != 1 {
@@ -168,7 +167,7 @@ impl Frame {
 impl std::fmt::Display for Frame {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Self::Header { salt, iv } => write!(
+			Self::Header { salt, iv, .. } => write!(
 				f,
 				"Header Frame (salt: {:02X?} (length: {}), iv: {:02X?} (length: {}))",
 				salt,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use anyhow::Context;
+use byteorder::ByteOrder;
 use byteorder::ReadBytesExt;
 use log::{debug, info};
 use std::convert::TryInto;
@@ -55,27 +56,30 @@ impl InputFile {
 		}
 	}
 
-	fn read_data(
-		&mut self,
-		length: usize,
-		read_attachment: bool,
-	) -> Result<Vec<u8>, anyhow::Error> {
-		let mut hmac = [0u8; crate::decrypter::LENGTH_HMAC];
-		let mut data;
+	fn read_decrypt_frame(&mut self) -> Result<Vec<u8>, anyhow::Error> {
+		// first read frame length
+		let mut encrypted_len = vec![0u8; 4];
+		self.reader.read_exact(&mut encrypted_len)?;
 
-		// Reading files (attachments) need an update of MAC with IV.
-		// And their given length corresponds to file length but frame length corresponds
-		// to data length + hmac data.
-		if read_attachment {
-			self.decrypter.mac_update_with_iv();
-			data = vec![0u8; length];
-		} else {
-			data = vec![0u8; length - crate::decrypter::LENGTH_HMAC];
-		}
+		// hmac will be updated with the encrypted_len data later
+		let decrypted_len = self.decrypter.decrypt(&encrypted_len, false);
+
+		let length: usize = byteorder::BigEndian::read_u32(&decrypted_len)
+			.try_into()
+			.unwrap();
+
+		let mut hmac = [0u8; crate::decrypter::LENGTH_HMAC];
+		let mut data = vec![0u8; 4 + length - crate::decrypter::LENGTH_HMAC];
 
 		// read data and decrypt
-		self.reader.read_exact(&mut data)?;
-		let data = self.decrypter.decrypt(&mut data);
+		self.reader.read_exact(&mut data[4..])?;
+		data[0] = encrypted_len[0];
+		data[1] = encrypted_len[1];
+		data[2] = encrypted_len[2];
+		data[3] = encrypted_len[3];
+
+		let mut data = self.decrypter.decrypt(&mut data, true);
+		data = data[4..].to_vec();
 
 		// read hmac
 		self.reader.read_exact(&mut hmac)?;
@@ -84,45 +88,60 @@ impl InputFile {
 		self.decrypter.verify_mac(&hmac)?;
 		self.decrypter.increase_iv();
 
-		if read_attachment {
-			// we got file length, so we have to add 10 bytes for hmac data
-			self.count_byte += length + crate::decrypter::LENGTH_HMAC;
-		} else {
-			// in the case of frames, we add 4 bytes we have read to determine frame length
-			// (hmac data is already in length included)
-			self.count_byte += length + std::mem::size_of::<u32>();
-		}
+		self.count_byte += length + std::mem::size_of::<u32>();
+
+		Ok(data)
+	}
+
+	fn read_decrypt_attachment(&mut self, length: usize) -> Result<Vec<u8>, anyhow::Error> {
+		let mut hmac = [0u8; crate::decrypter::LENGTH_HMAC];
+		let mut data;
+
+		// Reading files (attachments) need an update of MAC with IV.
+		// And their given length corresponds to file length but frame length corresponds
+		// to data length + hmac data.
+		self.decrypter.mac_update_with_iv();
+		data = vec![0u8; length];
+
+		// read data and decrypt
+		self.reader.read_exact(&mut data)?;
+		let data = self.decrypter.decrypt(&mut data, true);
+
+		// read hmac
+		self.reader.read_exact(&mut hmac)?;
+
+		// verify mac
+		self.decrypter.verify_mac(&hmac)?;
+		self.decrypter.increase_iv();
+
+		// we got file length, so we have to add 10 bytes for hmac data
+		self.count_byte += length + crate::decrypter::LENGTH_HMAC;
 
 		Ok(data)
 	}
 
 	pub fn read_frame(&mut self) -> Result<crate::frame::Frame, anyhow::Error> {
-		// read frame length from input file
-		let len: usize = self
-			.reader
-			.read_u32::<byteorder::BigEndian>()
-			.unwrap()
-			.try_into()
-			.unwrap();
+		let frame = self.read_decrypt_frame()?;
+
 		debug!(
 			"Read frame number {} with length of {} bytes",
-			self.count_frame, len
+			self.count_frame,
+			frame.len()
 		);
 
 		// create frame
-		let frame = self.read_data(len, false)?;
 		let mut frame: crate::frame::Frame = frame.try_into()?;
 		debug!("Frame type: {}", &frame);
 
 		match frame {
 			crate::frame::Frame::Attachment { data_length, .. } => {
-				frame.set_data(self.read_data(data_length, true)?);
+				frame.set_data(self.read_decrypt_attachment(data_length)?);
 			}
 			crate::frame::Frame::Avatar { data_length, .. } => {
-				frame.set_data(self.read_data(data_length, true)?);
+				frame.set_data(self.read_decrypt_attachment(data_length)?);
 			}
 			crate::frame::Frame::Sticker { data_length, .. } => {
-				frame.set_data(self.read_data(data_length, true)?);
+				frame.set_data(self.read_decrypt_attachment(data_length)?);
 			}
 			crate::frame::Frame::Header { .. } => return Err(anyhow!("unexpected header found")),
 			_ => (),


### PR DESCRIPTION
Fixes #58

I updated the Backups.proto file from here: https://github.com/signalapp/Signal-Android/blob/c6473ca9e63236af3eae9959a50cfa643d53272e/app/src/main/protowire/Backups.proto

I changed it so that the length is decrypted. However, the decryption wasn't straightforward, because the length is not a separate block, so I had to adapt the existing decrypt function a bit

Decryption in Signal:

```java
      int frameLength;
      if (BackupVersions.isFrameLengthEncrypted(version)) {
        mac.update(length);
        // this depends upon cipher being a stream cipher mode in order to get back the length without needing a full AES block-size input
        byte[] decryptedLength = cipher.update(length);
        if (decryptedLength.length != length.length) {
          throw new IOException("Cipher was not a stream cipher!");
        }
        frameLength = Conversions.byteArrayToInt(decryptedLength);
      } else {
        frameLength = Conversions.byteArrayToInt(length);
      }
```

https://github.com/signalapp/Signal-Android/commit/c6473ca9e63236af3eae9959a50cfa643d53272e#diff-cf445f7d302fb0629f925b7cf39cb340defe74a485bb7756159c6c9c86b31c0f